### PR TITLE
Added brackets to the "define_groups" foreach.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -275,8 +275,12 @@ function verbose_error_handler($errno, $errstr, $errfile, $errline) {
 function define_groups() {
 	global $config;
 
-	foreach ($config['mod']['groups'] as $group_value => $group_name)
-		defined($group_name) or define($group_name, $group_value, true);
+	foreach ($config['mod']['groups'] as $group_value => $group_name) {
+		$group_name = strtoupper($group_name); // added for the sake of semantics
+		if(!defined($group_name) {
+			define($group_name, $group_value, true);
+		}
+	}
 	
 	ksort($config['mod']['groups']);
 }


### PR DESCRIPTION
The installer wasn't working, so I added brackets to the foreach in the define_groups function and replaced the "or" statement with an if.

Also capitalised $group_name, because it was referenced in all caps.

Seemed to fix the installer.
